### PR TITLE
Namespace and create drawer fixes

### DIFF
--- a/client/css/section-editor.css
+++ b/client/css/section-editor.css
@@ -12,10 +12,10 @@ div.section-editor {
 
 .cs-tabs div.section-editor {
   position: absolute;
-  top: 134px;
-  bottom: 20px;
-  left: 20px;
-  right: 20px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   display: grid;
   grid-template-columns: 340px 1fr;
   grid-template-rows: minmax(55px, max-content);

--- a/client/css/tabs.css
+++ b/client/css/tabs.css
@@ -86,3 +86,8 @@
   padding: 20px;
   background: #fff;
 }
+
+.create-drawer .cs-tabs .react-tabs__tab-panel--selected {
+  position: relative;
+  flex-grow: 1;
+}

--- a/client/lib/helpers/session.jsx
+++ b/client/lib/helpers/session.jsx
@@ -148,7 +148,9 @@ export default {
         let result = data.context.result;
         window.localStorage["cs-config"] = JSON.stringify(result);
         window.localStorage["csos-user"] = JSON.stringify(result.user);
-        window.localStorage["csos-namespace"] = _.get(result.user, "defaultNamespace", "default");
+        if (!window.localStorage["csos-namespace"]) {
+          window.localStorage["csos-namespace"] = _.get(result.user, "defaultNamespace", "default");
+        }
         h.Vent.emit("main-menu:update");
         return callback(true);
       },

--- a/client/lib/layout/create/create-content.jsx
+++ b/client/lib/layout/create/create-content.jsx
@@ -41,14 +41,18 @@ class CreateContent extends React.Component {
         style={{
           border: 0,
           padding: "20px",
-          height: "100%",
-          marginBottom: "60px"
+          flexGrow: "1",
+          marginBottom: "0",
+          display: "flex",
+          flexDirection: "column"
         }}
       >
         <Tabs
           className="cs-tabs"
           style={{
-            height: "100%"
+            flexGrow: "1",
+            display: "flex",
+            flexDirection: "column"
           }}
           selectedIndex={this.state.index}
           onSelect={(tab) => this.handleTabClick(tab)}

--- a/client/lib/layout/create/create-drawer.jsx
+++ b/client/lib/layout/create/create-drawer.jsx
@@ -7,16 +7,15 @@ import CreateContent from "./create-content";
 
 const useStyles = makeStyles(() => ({
   root: {
-    display: "flex",
-    position: "fixed",
-    bottom: "10px",
-    right: "20px",
-    zIndex: 1000
+    // position: "fixed",
+    // bottom: "10px",
+    // right: "20px",
+    // zIndex: 1000
   },
   drawer: {
-    width: "100%",
-    height: "100%",
-    flexShrink: 0,
+    // width: "100%",
+    // height: "100%",
+    // flexShrink: 0,
   },
   drawerPaper: {
     width: "100%",
@@ -28,18 +27,13 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingRight: "20px",
-    paddingBottom: "20px",
+    padding: "10px 7px 10px 20px",
     backgroundColor: "#31383d"
   },
   drawerHeaderTitle: {
-    float: "left",
-    marginLeft: "19px",
     display: "flex",
-    justifyContent: "center",
     alignItems: "center",
     fontSize: "40px",
-    marginBottom: "-10px",
     color: "#fff"
   },
   drawerHeaderDefault: {

--- a/client/lib/layout/create/create-drawer.jsx
+++ b/client/lib/layout/create/create-drawer.jsx
@@ -6,17 +6,6 @@ import h from "../../helpers";
 import CreateContent from "./create-content";
 
 const useStyles = makeStyles(() => ({
-  root: {
-    // position: "fixed",
-    // bottom: "10px",
-    // right: "20px",
-    // zIndex: 1000
-  },
-  drawer: {
-    // width: "100%",
-    // height: "100%",
-    // flexShrink: 0,
-  },
   drawerPaper: {
     width: "100%",
     height: "100%",

--- a/client/lib/layout/create/wizards.jsx
+++ b/client/lib/layout/create/wizards.jsx
@@ -7,10 +7,10 @@ import resourceMetadata from "../../../shared/manifests/resource-metadata";
 const useStyles = makeStyles(() => ({
   root: {
     position: "absolute",
-    top: "134px",
-    bottom: "20px",
-    left: "20px",
-    right: "20px"
+    top: "0",
+    bottom: "0",
+    left: "0",
+    right: "0"
   },
   content: {
     padding: "40px",


### PR DESCRIPTION
# Description

- Fixed namespace getting reset to default on page reload
- Fixed styles in Create Resource drawer because header was getting cut off

![create-drawer](https://user-images.githubusercontent.com/17789910/99316886-1d014e00-2833-11eb-9d86-97e9f985c1b5.png)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
